### PR TITLE
Fix a few edge cases of diffing column constraints

### DIFF
--- a/src/Database/Beam/AutoMigrate/Postgres.hs
+++ b/src/Database/Beam/AutoMigrate/Postgres.hs
@@ -216,9 +216,16 @@ extensionTypeNamesQ =
         "WHERE ns.nspname = 'public' AND ty.typcategory = 'U' "
       ]
 
+-- | Used to ensure timestamps are reported in UTC, which helps make default constraint parsing/comparison a little
+-- simpler.
+setLocalTimeZoneUTC :: Pg.Query
+setLocalTimeZoneUTC =
+  fromString "SET LOCAL TimeZone TO 'UTC'"
+
 -- | Connects to a running PostgreSQL database and extract the relevant 'Schema' out of it.
 getSchema :: Pg.Connection -> IO Schema
 getSchema conn = do
+  _ <- Pg.execute_ conn setLocalTimeZoneUTC
   allTableConstraints <- getAllConstraints conn
   allDefaults <- getAllDefaults conn
   extensionTypeData <- Pg.fold_ conn extensionTypeNamesQ mempty getExtension


### PR DESCRIPTION
1. Column constraints were being removed after being added, resulting
in deleting the constraint in any case where it changed.
2. Default timestamp with time zone column constraints were being
compared too naively. Now we at least attempt to parse the formats
produced by postgresql-simple and postgres itself, and if we can,
compare the resulting UTCTimes to see if anything needs to change.
To aid this, we also set the transaction-local time zone to UTC before
getting the schema, so that absolute timestamps in default constraints
are reported in UTC time.
3. Default enumeration values were getting type-annotated by postgres
but not by the Haskell side, we try to look for this and avoid changing
things if it's the only difference.